### PR TITLE
Use conda-build's Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,12 @@ CFLAGS  = "-I$(UCX_PATH)/include -I$(CUDA_PATH)/include"
 LDFLAGS = "-L$(UCX_PATH)/lib -L$(CUDA_PATH)/lib64"
 
 install:
-	LDFLAGS=$(LDFLAGS) CFLAGS=$(CFLAGS) python3 setup.py build_ext -i --with-cuda
-	python3 -m pip install -e .
+	LDFLAGS=$(LDFLAGS) CFLAGS=$(CFLAGS) $(PYTHON) setup.py build_ext -i --with-cuda
+	$(PYTHON) -m pip install -e .
 
 install-cpu:
-	LDFLAGS=$(LDFLAGS) CFLAGS=$(CFLAGS) python3 setup.py build_ext -i
-	python3 -m pip install -e .
+	LDFLAGS=$(LDFLAGS) CFLAGS=$(CFLAGS) $(PYTHON) setup.py build_ext -i
+	$(PYTHON) -m pip install -e .
 
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ CUDA_PATH ?= "/usr/local/cuda"
 CFLAGS  = "-I$(UCX_PATH)/include -I$(CUDA_PATH)/include"
 LDFLAGS = "-L$(UCX_PATH)/lib -L$(CUDA_PATH)/lib64"
 
+PYTHON ?= python3
+
 install:
 	LDFLAGS=$(LDFLAGS) CFLAGS=$(CFLAGS) $(PYTHON) setup.py build_ext -i --with-cuda
 	$(PYTHON) -m pip install -e .


### PR DESCRIPTION
Makes use of conda-build's Python via the [environment variable it sets]( https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html#environment-variables-set-during-the-build-process ). Default to the first `python3` if nothing else can be found.