### PR TITLE
assign random port to listener if port=0 passed

### DIFF
--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -5,15 +5,13 @@ import ucp
 async def talk_to_client(ep, listener):
     recv_req = await ep.recv_future()
     recv_msg = ucp.get_obj_from_msg(recv_req)
-    #print('Client connected')
+    ucp.destroy_ep(ep)
     ucp.stop_listener(listener)
-    #ucp.destroy_ep(ep)
     
 async def talk_to_server(ip, port):
     ep = ucp.get_endpoint(ip, port)
     await ep.send_obj(bytes(b"42"))
-    #print('Client done')
-    #ucp.destroy_ep(ep)
+    ucp.destroy_ep(ep)
 
 @pytest.mark.asyncio
 async def test_zero_port():
@@ -22,8 +20,6 @@ async def test_zero_port():
     assert 0 < listener.port < 2**16
     
     ip = ucp.get_address()
-    #print(ip)
-    #print(listener.port)
     await asyncio.gather(
         listener.coroutine,
         talk_to_server(ip.encode(), listener.port)

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -1,0 +1,31 @@
+import pytest
+import asyncio
+import ucp
+
+async def talk_to_client(ep, listener):
+    recv_req = await ep.recv_future()
+    recv_msg = ucp.get_obj_from_msg(recv_req)
+    #print('Client connected')
+    ucp.stop_listener(listener)
+    #ucp.destroy_ep(ep)
+    
+async def talk_to_server(ip, port):
+    ep = ucp.get_endpoint(ip, port)
+    await ep.send_obj(bytes(b"42"))
+    #print('Client done')
+    #ucp.destroy_ep(ep)
+
+@pytest.mark.asyncio
+async def test_zero_port():
+    ucp.init()
+    listener = ucp.start_listener(talk_to_client, listener_port=0, is_coroutine=True)
+    assert 0 < listener.port < 2**16
+    
+    ip = ucp.get_address()
+    #print(ip)
+    #print(listener.port)
+    await asyncio.gather(
+        listener.coroutine,
+        talk_to_server(ip.encode(), listener.port)
+    )
+    ucp.fin()

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -594,6 +594,17 @@ def start_listener(py_func, listener_port = -1, is_coroutine = False):
         reader_added = 1
 
     port = listener_port
+    if 0 == port:
+        """ Ref https://unix.stackexchange.com/a/132524"""
+        import socket
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(('', 0))
+        addr = s.getsockname()
+        #print('random port requested')
+        #print(addr[1])
+        s.close()
+        port = addr[1]
+
     listener.listener_ptr = ucp_py_listen(accept_callback, <void *>lf, <int *> &port)
     if <void *> NULL != listener.listener_ptr:
         lf.ucp_listener = listener

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -614,7 +614,7 @@ def start_listener(py_func, listener_port = -1, is_coroutine = False):
 
         num_tries += 1
         if num_tries > max_tries:
-            return None
+            raise NameError('Unable to bind to an open port after {max_tries} attempts')
 
 def stop_listener(lf):
     """Stop listening for incoming connections

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -600,8 +600,6 @@ def start_listener(py_func, listener_port = -1, is_coroutine = False):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.bind(('', 0))
         addr = s.getsockname()
-        #print('random port requested')
-        #print(addr[1])
         s.close()
         port = addr[1]
 

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -594,21 +594,27 @@ def start_listener(py_func, listener_port = -1, is_coroutine = False):
         reader_added = 1
 
     port = listener_port
-    if 0 == port:
-        """ Ref https://unix.stackexchange.com/a/132524"""
-        import socket
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(('', 0))
-        addr = s.getsockname()
-        s.close()
-        port = addr[1]
+    max_tries = 10000 # Arbitrary for now
+    num_tries = 0
+    while True:
+        if 0 == port:
+            """ Ref https://unix.stackexchange.com/a/132524"""
+            import socket
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.bind(('', 0))
+            addr = s.getsockname()
+            s.close()
+            port = addr[1]
 
-    listener.listener_ptr = ucp_py_listen(accept_callback, <void *>lf, <int *> &port)
-    if <void *> NULL != listener.listener_ptr:
-        lf.ucp_listener = listener
-        lf.port = port
-    return lf
+        listener.listener_ptr = ucp_py_listen(accept_callback, <void *>lf, <int *> &port)
+        if <void *> NULL != listener.listener_ptr:
+            lf.ucp_listener = listener
+            lf.port = port
+            return lf
 
+        num_tries += 1
+        if num_tries > max_tries:
+            return None
 
 def stop_listener(lf):
     """Stop listening for incoming connections

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -597,6 +597,7 @@ def start_listener(py_func, listener_port = -1, is_coroutine = False):
     max_tries = 10000 # Arbitrary for now
     num_tries = 0
     while True:
+	    
         if 0 == port:
             """ Ref https://unix.stackexchange.com/a/132524"""
             import socket
@@ -614,7 +615,7 @@ def start_listener(py_func, listener_port = -1, is_coroutine = False):
 
         num_tries += 1
         if num_tries > max_tries:
-            raise NameError('Unable to bind to an open port after {max_tries} attempts')
+            raise NameError('Unable to bind to an open port after {} attempts'.format(max_tries))
 
 def stop_listener(lf):
     """Stop listening for incoming connections


### PR DESCRIPTION
@mrocklin @quasiben 

Getting port information from UCX may take time. Refer https://github.com/openucx/ucx/issues/3534
Will the logic included in this PR suffice for now? 

Example usage:

```python
# Server
In [1]: import ucp

In [2]: ucp.init()
Out[2]: 0

In [3]: import asyncio

In [4]: loop = asyncio.get_event_loop()

In [5]: async def talk_to_client(ep, listener):
   ...:     recv_req = await ep.recv_future()
   ...:     recv_msg = ucp.get_obj_from_msg(recv_req)
   ...:     print('client connected')
   ...:     ucp.destroy_ep(ep)
   ...: 

In [6]: listener = ucp.start_listener(talk_to_client, listener_port=0, is_coroutine=True)

In [7]: coro = listener.coroutine

In [8]: listener.port
Out[8]: 49038

In [9]: loop.run_until_complete(coro)
client connected

```

```python
# Client
In [1]: import ucp

In [2]: import asyncio

In [3]: ucp.init()
Out[3]: 0

In [4]: loop = asyncio.get_event_loop()

In [5]: async def talk_to_client(ip, port):
    ...:     ep = ucp.get_endpoint(ip, port)
    ...:     await ep.send_obj(bytes(b"42"))
    ...:     ucp.destroy_ep(ep)
    ...: 

In [6]: coro = talk_to_client('A.B.C.D'.encode(), 49038)

In [7]: loop.run_until_complete(coro)
```