### PR TITLE
Retry connection establishment

### DIFF
--- a/tests/send-recv-py-obj.py
+++ b/tests/send-recv-py-obj.py
@@ -110,7 +110,7 @@ async def talk_to_client(ep, listener):
 
 async def talk_to_server(ip, port):
     # recv, send
-    ep = ucp.get_endpoint(ip, port)
+    ep = await ucp.get_endpoint(ip, port)
 
     if not args.blind_recv:
         recv_req = await ep.recv_obj(args.n_bytes)

--- a/tests/send-recv-py-obj.py
+++ b/tests/send-recv-py-obj.py
@@ -110,7 +110,7 @@ async def talk_to_client(ep, listener):
 
 async def talk_to_server(ip, port):
     # recv, send
-    ep = await ucp.get_endpoint(ip, port)
+    ep = await ucp.get_endpoint(ip, port, timeout=10)
 
     if not args.blind_recv:
         recv_req = await ep.recv_obj(args.n_bytes)

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,0 +1,19 @@
+import pytest
+import asyncio
+import ucp
+import time
+
+async def talk_to_server(ip, port, timeout):
+    try:
+        ep = await ucp.get_endpoint(ip, port, timeout)
+    except TimeoutError:
+        pass
+
+@pytest.mark.asyncio
+async def test_timeout():
+    ucp.init()
+    ip = ucp.get_address()
+    await asyncio.gather(
+        talk_to_server(ip.encode(), 9999, timeout=0.1)
+    )
+    ucp.fin()

--- a/ucp/_libs/src/ucp_py_ucp_fxns.c
+++ b/ucp/_libs/src/ucp_py_ucp_fxns.c
@@ -702,7 +702,6 @@ int ucp_py_init(void)
     int err = 0;
     int epoll_fd_local = 0, epoll_fd = 0;
     struct epoll_event ev;
-    char *env_str;
     ev.data.u64 = 0;
 
     if (0 != gethostname(my_hostname, HNAME_MAX_LEN)) goto err_py_init;

--- a/ucp/_libs/src/ucp_py_ucp_fxns.c
+++ b/ucp/_libs/src/ucp_py_ucp_fxns.c
@@ -635,7 +635,7 @@ void *ucp_py_get_ep(char *ip, int listener_port)
             ucp_request_cancel(ucp_py_ctx_head->ucp_worker, &request);
             request_init(request);
             ucp_request_free(request);
-            DEBUG_PRINT("connection failed. Retrying in %d seconds\n",
+            printf("connection failed. Retrying in %d seconds\n",
                         ucp_py_ctx_head->connection_retry_period);
             connection_status = EP_CONN_INIT;
             sleep(ucp_py_ctx_head->connection_retry_period);
@@ -656,7 +656,7 @@ void *ucp_py_get_ep(char *ip, int listener_port)
                 ucp_request_cancel(ucp_py_ctx_head->ucp_worker, &request);
                 request_init(request);
                 ucp_request_free(request);
-                DEBUG_PRINT("connection failed. Retrying in %d seconds\n",
+                printf("connection failed. Retrying in %d seconds\n",
                             ucp_py_ctx_head->connection_retry_period);
                 connection_status = EP_CONN_INIT;
                 sleep(ucp_py_ctx_head->connection_retry_period);

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -710,7 +710,7 @@ def fin():
         return ucp_py_finalize()
 
 @ucp_logger
-async def get_endpoint(peer_ip, peer_port, timeout=5):
+async def get_endpoint(peer_ip, peer_port, timeout=10):
     """Connect to a peer running at `peer_ip` and `peer_port`
 
     Parameters
@@ -729,11 +729,18 @@ async def get_endpoint(peer_ip, peer_port, timeout=5):
     global reader_added
 
     ep = Endpoint()
-    while True:
+    deadline = time.time() + timeout
+    connection_established = False
+    while time.time() <= deadline:
         if -1 == ep.connect(peer_ip, peer_port):
-            await asyncio.sleep(timeout)
+            await asyncio.sleep(1)
         else:
+            connection_established = True
             break
+
+    if not connection_established:
+        raise NameError('Timeout in connection establishment attempt')
+        return None
 
     if 0 == reader_added:
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
- if client appears before server which listens, this PR allows the client to wait for `UCXPY_CONN_RETRY_PERIOD` seconds, and retry connection establishment for a maximum of `EP_CONN_MAX_RETRIES` attempts.
```
# client
akvenkatesh@prm-dgx-10:~/ucx-py$ UCXPY_CONN_RETRY_PERIOD=2 UCX_MEMTYPE_CACHE=n UCX_RNDV_SCHEME=put_zcopy python3 tests/send-recv-py-obj.py -o cupy -s IP -p 13337
[1558033604.520057] [prm-dgx-10:81187:1]   rdmacm_iface.c:401  UCX  ERROR received event RDMA_CM_EVENT_UNREACHABLE. status = 1. Peer: IP:13337.
connection failed. Retrying in 2 seconds
[1558033606.523174] [prm-dgx-10:81187:1]   rdmacm_iface.c:401  UCX  ERROR received event RDMA_CM_EVENT_UNREACHABLE. status = 1. Peer: IP:13337.
connection failed. Retrying in 2 seconds
[1558033608.526044] [prm-dgx-10:81187:0]   rdmacm_iface.c:401  UCX  ERROR received event RDMA_CM_EVENT_UNREACHABLE. status = 1. Peer: IP:13337.
connection failed. Retrying in 2 seconds
about to reply
talk_to_server done

# server which arrives later
akvenkatesh@prm-dgx-10:~/ucx-py$ UCX_MEMTYPE_CACHE=n UCX_RNDV_SCHEME=put_zcopy python3 tests/send-recv-py-obj.py -o cupy
about to send
about to recv
server sent:  array([48, 48..., dtype=uint8) <class 'cupy.core.core.ndarray'>
server recv:  array([48, 48..., dtype=uint8) <class 'cupy.core.core.ndarray'>
talk_to_client done
```